### PR TITLE
fix base64 for heroku

### DIFF
--- a/lib/kraken_ruby/client.rb
+++ b/lib/kraken_ruby/client.rb
@@ -1,6 +1,6 @@
 require 'httparty'
 require 'hashie'
-require 'Base64'
+require 'base64'
 require 'addressable/uri'
 
 

--- a/lib/kraken_ruby/version.rb
+++ b/lib/kraken_ruby/version.rb
@@ -1,3 +1,3 @@
 module KrakenRuby
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
require "base64" with capital B was creating an error on script ran in heroku.

Now it's working great
