### PR TITLE
base64 and nonce patches

### DIFF
--- a/lib/kraken_ruby/client.rb
+++ b/lib/kraken_ruby/client.rb
@@ -140,7 +140,8 @@ module Kraken
       end
 
       def nonce
-        Time.now.to_i.to_s.ljust(16,'0')
+        len = 16
+        SecureRandom.random_number(10 ** len).to_s.ljust(len, '0')
       end
 
       def encode_options(opts)

--- a/lib/kraken_ruby/version.rb
+++ b/lib/kraken_ruby/version.rb
@@ -1,3 +1,3 @@
 module KrakenRuby
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
Includes @jhk753's `Base64` fix and also an update to the `nonce` method (best practice is not to base nonce values off of timestamps).
