### PR TITLE
Fix Gemspec

### DIFF
--- a/kraken_ruby.gemspec
+++ b/kraken_ruby.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://www.kraken.com/help/api"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($/).delete_if { |f| f =~ /\.gem$/ }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Do not include .gem files in themselves.
Bundler throws all kinds of errors because .gem files were included in the gem itself.
Came up with this error: http://stackoverflow.com/questions/16210910/bundle-update-fileoverflow-file-too-large