### PR TITLE
Create a more granular nonce to prevent EAPI:invalid nonce errors

### DIFF
--- a/lib/kraken_ruby/client.rb
+++ b/lib/kraken_ruby/client.rb
@@ -143,13 +143,13 @@ module Kraken
         r['error'].empty? ? r['result'] : r['error']
       end
 
-      # Generate a 64-bit nonce where the 32 high bits come directly from the current
-      # timestamp and the low 32 bits are pseudorandom. We can't use a pure [P]RNG here
+      # Generate a 64-bit nonce where the 48 high bits come directly from the current
+      # timestamp and the low 16 bits are pseudorandom. We can't use a pure [P]RNG here
       # because the Kraken API requires every request within a given session to use a
       # monotonically increasing nonce value. This approach splits the difference.
       def nonce
-        high_bits = Time.now.to_i << 32
-        low_bits  = SecureRandom.random_number(2 ** 32) & 0xffffffff
+        high_bits = (Time.now.to_f * 10000).to_i << 16
+        low_bits  = SecureRandom.random_number(2 ** 16) & 0xffff
         (high_bits | low_bits).to_s
       end
 


### PR DESCRIPTION
The current nonce algorithm prevents parallel requests within one second. Modified it to be more granular (1/10000 seconds).