### PR TITLE
Add querying deposit and withdrawal info

### DIFF
--- a/lib/kraken_ruby/client.rb
+++ b/lib/kraken_ruby/client.rb
@@ -119,6 +119,10 @@ module Kraken
       post_private 'DepositStatus', opts
     end
 
+    def withdraw_status(opts={})
+      post_private 'WithdrawStatus', opts
+    end
+
     #### Private User Trading ####
 
     def add_order(opts={})

--- a/lib/kraken_ruby/client.rb
+++ b/lib/kraken_ruby/client.rb
@@ -110,6 +110,11 @@ module Kraken
       post_private 'TradeVolume', opts
     end
 
+    def deposit_methods(asset, opts={})
+      opts['asset'] = asset
+      post_private 'DepositMethods', opts
+    end
+
     #### Private User Trading ####
 
     def add_order(opts={})

--- a/lib/kraken_ruby/client.rb
+++ b/lib/kraken_ruby/client.rb
@@ -115,6 +115,10 @@ module Kraken
       post_private 'DepositMethods', opts
     end
 
+    def deposit_status(opts={})
+      post_private 'DepositStatus', opts
+    end
+
     #### Private User Trading ####
 
     def add_order(opts={})

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -69,6 +69,22 @@ describe Kraken::Client do
       expect(result).to have_key 'limit'
       expect(result).to have_key 'fee'
     end
+
+    it "gets deposit status" do
+      results = kraken.deposit_status(asset: "XXBT")
+      expect(results).to be_instance_of(Array)
+      if result = results.first
+        expect(result).to have_key 'method'
+        expect(result).to have_key 'aclass'
+        expect(result).to have_key 'refid'
+        expect(result).to have_key 'txid'
+        expect(result).to have_key 'info'
+        expect(result).to have_key 'amount'
+        expect(result).to have_key 'fee'
+        expect(result).to have_key 'status'
+        expect(result).to have_key 'time'
+      end
+    end
 	end
 
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -85,6 +85,22 @@ describe Kraken::Client do
         expect(result).to have_key 'time'
       end
     end
-	end
 
+    it "gets withdraw status" do
+      results = kraken.withdraw_status(asset: "XXBT")
+      pp results
+      expect(results).to be_instance_of(Array)
+      if result = results.first
+        expect(result).to have_key 'method'
+        expect(result).to have_key 'aclass'
+        expect(result).to have_key 'refid'
+        expect(result).to have_key 'txid'
+        expect(result).to have_key 'info'
+        expect(result).to have_key 'amount'
+        expect(result).to have_key 'fee'
+        expect(result).to have_key 'status'
+        expect(result).to have_key 'time'
+      end
+    end
+  end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -62,6 +62,13 @@ describe Kraken::Client do
       nonce = kraken.send :nonce
       expect(nonce.to_i.size).to eq(8)
     end
+
+    it "gets deposit methods" do
+      result = kraken.deposit_methods("XXBT").first
+      expect(result).to have_key 'method'
+      expect(result).to have_key 'limit'
+      expect(result).to have_key 'fee'
+    end
 	end
 
 end


### PR DESCRIPTION
Allows an API client to query recent deposits and withdrawals.

A bug in Kraken's API prevents `withdraw_status` to be called with the "Query Funds" permission. 

You need withdrawal permission to be able to get withdrawal details.
